### PR TITLE
fix by adding \ to u0026 replacement in m3u8 URL

### DIFF
--- a/resources/lib/roosterteeth_play.py
+++ b/resources/lib/roosterteeth_play.py
@@ -294,7 +294,7 @@ class Main(object):
         if found_m3u8_url:
             # for some reason u0026 is present in the url, it should have been an ampersand
             # let's correct that
-            m3u8_url = m3u8_url.replace('u0026', '&')
+            m3u8_url = m3u8_url.replace('\u0026', '&')
 
             log("corrected m3u8_url", m3u8_url)
 


### PR DESCRIPTION
The plugin stopped working for me in the last couple of days and I was getting "No video found" errors.

Looks like the CDN is rejecting the m3u8 URL (specifically the `Signature`) due to stray backslashes left over from the u0026 replacement. Replacing the backslash at the beginning of `\u0026` fixed it for me.

I'm not exactly sure what will have changed to cause this error, but here's the answer :)