### PR TITLE
Prevent embedded ads for first members by always logging in

### DIFF
--- a/resources/lib/roosterteeth_play.py
+++ b/resources/lib/roosterteeth_play.py
@@ -109,8 +109,8 @@ class Main(object):
 
             log("must_login_first_member_user", must_login_first_member_user)
 
-            # login if needed
-            if must_login_first_member_user:
+            # RT now embeds ads in public streams, so we must always log in
+            #if must_login_first_member_user:
                 # is the first_member switch in the settings of this addon turned on?
                 if self.IS_FIRST_MEMBER == 'true':
                     # is it a first_member video or not?
@@ -210,28 +210,28 @@ class Main(object):
 
                             exit(1)
 
-                    except urllib.error.HTTPError as error:
+                except urllib.error.HTTPError as error:
 
-                        log("HTTPError1", error)
+                    log("HTTPError1", error)
 
-                        try:
-                            dialog_wait.close()
-                            del dialog_wait
-                        except:
-                            pass
-                        xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30106) % (convertToUnicodeString(error)))
-                        exit(1)
+                    try:
+                        dialog_wait.close()
+                        del dialog_wait
                     except:
-                        exception = sys.exc_info()[0]
+                        pass
+                    xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30106) % (convertToUnicodeString(error)))
+                    exit(1)
+                except:
+                    exception = sys.exc_info()[0]
 
-                        log("ExceptionError1", exception)
+                    log("ExceptionError1", exception)
 
-                        try:
-                            dialog_wait.close()
-                            del dialog_wait
-                        except:
-                            pass
-                        exit(1)
+                    try:
+                        dialog_wait.close()
+                        del dialog_wait
+                    except:
+                        pass
+                    exit(1)
 
                 else:
                     try:


### PR DESCRIPTION
Hi @skipmodea1!

I've started seeing ads for some videos, which must be embedded in the streams now.

From what I gather, we currently skip the login step for public videos, only logging in when the video is first member only. I suggest we now log in every time so that first members don't get the ad version of the steam.

I removed the entire condition...

```
if must_login_first_member_user:
```

...but you might think it cleaner to simply set `must_login_first_member_user` to true prior to that.

```
                if html_source.find("not yet available") >= 0:
                    # let's try and get this non-first_member video after login in the first_member user then
                    must_login_first_member_user = True
                    video_is_not_yet_available = True
                else:
                    must_login_first_member_user = False
                    video_is_not_yet_available = False
```

I've tested this on Kodi for MacOS and two of my Vero 4K boxes—all running OSMC.

Thanks!